### PR TITLE
ZS2022-36 Negative flow test for WarrantyEndDate (#16)

### DIFF
--- a/src/main/java/pageObjects/DevicePage.java
+++ b/src/main/java/pageObjects/DevicePage.java
@@ -2,12 +2,14 @@ package pageObjects;
 
 import driver.DriverFactory;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.text.ParseException;
 import java.util.concurrent.TimeUnit;
 
 import static utils.Constants.DEVICE_DESCRIPTION;
@@ -18,6 +20,7 @@ import static utils.Constants.DEVICE_NAME_TOO_LONG;
 import static utils.Constants.DEVICE_NAME_WS;
 import static utils.Constants.DEVICE_NUMBER_OVER_30_CHAR;
 import static utils.Constants.DEVICE_SERIAL_NO_WS;
+import static utils.RandomGenerator.randomDateBefore;
 import static utils.RandomGenerator.randomName;
 import static utils.RandomGenerator.randomNumber;
 
@@ -85,6 +88,9 @@ public class DevicePage extends DriverFactory {
 
     @FindBy(id = "assign_update")
     private WebElement assignUpdateButton;
+
+    @FindBy(id = "device-information-endWarranty")
+    private WebElement endWarrantyField;
 
     public void successfullyCreateDevice() {
         signInAsAdmin();
@@ -364,5 +370,38 @@ public class DevicePage extends DriverFactory {
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("device_delete_" + inactiveDeviceName)));
         driver.findElement(By.id("device_delete_" + inactiveDeviceName)).click();
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("success_toaster")));
+    }
+
+    public void createDeviceInvalidWarrantyEndDate() {
+        signInAsAdmin();
+        deviceName = randomName();
+        serialNo = randomNumber();
+        inventoryNo = randomNumber();
+        invoiceNo = randomNumber();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("undefined-devices-mButton")));
+        devicesButton.click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("add_device_button")));
+        addDeviceButton.click();
+        nameField.sendKeys(deviceName);
+        serialNoField.sendKeys(serialNo + "");
+        inventoryNoField.sendKeys(inventoryNo + "");
+        invoiceNoField.sendKeys(invoiceNo + "");
+        descriptionField.sendKeys(DEVICE_DESCRIPTION);
+        endWarrantyField.click();
+        endWarrantyField.sendKeys(Keys.CONTROL + "a");
+        endWarrantyField.sendKeys(Keys.DELETE);
+        try {
+            endWarrantyField.sendKeys(randomDateBefore());
+        } catch (ParseException parseException){
+            parseException.printStackTrace();
+        }
+        subcategoryList.click();
+        subcategoryLaptopListElement.click();
+        tagsList.click();
+        tagsListElement.click();
+        locationsList.click();
+        locationsRomaniaListElement.click();
+        saveDeviceButton.click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("error_toaster")));
     }
 }

--- a/src/main/java/utils/RandomGenerator.java
+++ b/src/main/java/utils/RandomGenerator.java
@@ -1,5 +1,10 @@
 package utils;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Random;
 import java.util.UUID;
 
@@ -15,4 +20,9 @@ public class RandomGenerator {
         return name.replaceAll("-", "");
     }
 
+    public static String randomDateBefore() throws ParseException {
+        String randomDate = String.valueOf(Instant.now().minus(Duration.ofDays(random.nextInt(365) + 1)));
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse(randomDate);
+        return new SimpleDateFormat("MM/dd/yyyy").format(date);
+    }
 }

--- a/src/test/java/pageObjects/DevicePageTests.java
+++ b/src/test/java/pageObjects/DevicePageTests.java
@@ -167,6 +167,12 @@ public class DevicePageTests extends BaseTest {
         Assert.assertEquals(text, "Item deleted successfully!");
         String deviceRowText = driver.findElement(By.id("device-table-row-0")).getText();
         Assert.assertTrue(deviceRowText.contains("inactive"));
+    }
 
+    @Test
+    public void createDeviceInvalidWarrantyEndDate() {
+        devicePage.createDeviceInvalidWarrantyEndDate();
+        WebElement errorToaster = driver.findElement(By.id("error_toaster"));
+        Assert.assertEquals(errorToaster.getText(),"The field \"warrantyEndDate\" is inconsistent.");
     }
 }


### PR DESCRIPTION
ZS2022-28
Automated tests for creating a license:

- successfulCreateLicense
- checkIfNameFieldIsMandatory
- createDeviceWithTooLongName
- saveLicenseWhiteSpaceNameField
- createLicenseWithIndividualType
- createLicenseWithPackType
- createLicenseWithLocation
- createLicenseWithEmptyNameField
- createLicenseWithExpirationDateEarlierThanPurchaseDate
- createLicenseWithEmptyExpirationDate
- createLicenseWithEmptyPurchaseDate
- successfulEditLicenseName